### PR TITLE
Avoid double builds on OSX

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 var (
 	watcher  *fsnotify.Watcher
 	watched  = make(map[string]struct{})
+	mtimes   = make(map[string]time.Time)
 	exitCode = make(chan int)
 	rootPath string
 
@@ -78,7 +79,22 @@ func fullBuild() {
 }
 
 func maybeQueueBuild(path string) {
-	buildQueued = hasSuffix(path, ".go")
+	if !hasSuffix(path, ".go") {
+		return
+	}
+
+	// Check whether the modified time has actually changed. This is
+	// useful on systems that may emit multiple change events for a
+	// single change (e.g. OSX + Spotlight)
+	fi, err := os.Stat(path)
+	if err == nil {
+		mtime := fi.ModTime()
+		lasttime := mtimes[path]
+		if !mtime.Equal(lasttime) {
+			mtimes[path] = mtime
+			buildQueued = true
+		}
+	}
 }
 
 func handleCreate(path string) {


### PR DESCRIPTION
Thanks for glitch. It's useful.

I noticed that every file save was generating multiple builds. It's most likely due to double events from OSX + Spotlight (https://github.com/howeyc/fsnotify/issues/62). This commit addresses it by testing whether the file's mtime is different, which it isn't under this double event scenario.

The change also fixes a bug in the buildQueued logic. The variable was simply getting set to the most recent hasSuffix() call, which would fail to trigger a build if a non-Go file was modified last. You can see this with:  `touch app.go; touch readme.txt`. The buildQueued state should latch to true.
